### PR TITLE
Fix GH-22 wrong method for Android docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ public class MyApplication extends Application {
   public void onCreate() {
     super.onCreate();
 
-    if (BuildConfig.DEBUG && SonarUtils.shouldEnableClient(this)) {
+    if (BuildConfig.DEBUG && SonarUtils.shouldEnableSonar(this)) {
       final SonarClient client = AndroidSonarClient.getInstance(this);
       client.addPlugin(new MySonarPlugin());
       client.start();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ public class MyApplication extends Application {
   public void onCreate() {
     super.onCreate();
 
-    if (BuildConfig.DEBUG && SonarUtils.isMainProcess(mApplicationContext)) {
+    if (BuildConfig.DEBUG && SonarUtils.shouldEnableClient(this)) {
       final SonarClient client = AndroidSonarClient.getInstance(this);
       client.addPlugin(new MySonarPlugin());
       client.start();


### PR DESCRIPTION
As per GH-14 comment, the docs were pointing to an internal `private` method to check if `Sonar` should be enabled