### PR TITLE
Add missing Android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -161,6 +161,7 @@ android {
         implementation deps.supportAppCompat
         implementation deps.stetho
         implementation deps.okhttp3
+        implementation deps.rhino
         implementation 'com.facebook.litho:litho-core:0.15.0'
         implementation 'com.facebook.litho:litho-widget:0.15.0'
         implementation fileTree(dir: 'plugins/console/dependencies', include: ['*.jar'])

--- a/android/res/values/ids.xml
+++ b/android/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="sonar_skip_view_traversal" type="id" />
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext.deps = [
         guava              : 'com.google.guava:guava:20.0',
         robolectric        : 'org.robolectric:robolectric:3.0',
         junit              : 'junit:junit:4.12',
-        guava              : 'com.google.guava:guava:20.0',
+        rhino              : 'org.mozilla:rhino:1.7.10',
         stetho             : 'com.facebook.stetho:stetho:1.5.0',
         okhttp3            : 'com.squareup.okhttp3:okhttp:3.10.0'
 


### PR DESCRIPTION
Seems like the Android build depends on Rhino but the dependency is not declared, and there's a `/res` directory listed in the sourceSets, but the directory doesn't exist. I _think_ this should cover those cases (and delete a duplicate guava dependency in the deps list).