### PR TITLE
Centralize sample dependencies

### DIFF
--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -34,28 +34,28 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
-    implementation 'com.android.support:design:26.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation deps.supportAppCompat
+    implementation deps.supportConstraintLayout
+    implementation deps.supportDesign
+    testImplementation deps.junit
+    androidTestImplementation deps.supportTestRunner
+    androidTestImplementation deps.supportEspresso
     // Litho
-    implementation 'com.facebook.litho:litho-core:0.15.0'
-    implementation 'com.facebook.litho:litho-widget:0.15.0'
-    compileOnly 'com.facebook.litho:litho-annotations:0.15.0'
+    implementation deps.lithoCore
+    implementation deps.lithoWidget
+    compileOnly deps.lithoAnnotations
 
-    annotationProcessor 'com.facebook.litho:litho-processor:0.15.0'
+    annotationProcessor deps.lithoProcessor
 
     // SoLoader
-    implementation 'com.facebook.soloader:soloader:0.4.1'
+    implementation deps.soloader
 
     // For integration with Fresco
-    implementation 'com.facebook.litho:litho-fresco:0.15.0'
+    implementation deps.lithoFresco
 
     // For testing
-    testImplementation 'com.facebook.litho:litho-testing:0.15.0'
+    testImplementation deps.lithoTesting
 
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation deps.okhttp3
     implementation project(':android')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ ext.deps = [
         supportAppCompat   : 'com.android.support:appcompat-v7:27.1.1',
         supportCoreUi      : 'com.android.support:support-core-ui:27.1.1',
         supportRecyclerView: 'com.android.support:recyclerview-v7:27.1.1',
+        supportConstraintLayout: 'com.android.support.constraint:constraint-layout:1.1.0',
         supportEspresso    : 'com.android.support.test.espresso:espresso-core:2.2.2',
+        supportDesign      : 'com.android.support:design:27.1.1',
         supportEspressoIntents : 'com.android.support.test.espresso:espresso-intents:2.2.2',
         supportTestRunner  : 'com.android.support.test:runner:1.0.2',
         // Arch
@@ -46,12 +48,17 @@ ext.deps = [
         // Annotations
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.1',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',
+        // Litho
         lithoAnnotations   : 'com.facebook.litho:litho-annotations:0.15.0',
+        lithoCore          : 'com.facebook.litho:litho-core:0.15.0',
+        lithoWidget        : 'com.facebook.litho:litho-widget:0.15.0',
+        lithoProcessor     : 'com.facebook.litho:litho-processor:0.15.0',
+        lithoFresco        : 'com.facebook.litho:litho-fresco:0.15.0',
+        lithoTesting       : 'com.facebook.litho:litho-testing:0.15.0',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
         robolectric        : 'org.robolectric:robolectric:3.0',
         junit              : 'junit:junit:4.12',
         stetho             : 'com.facebook.stetho:stetho:1.5.0',
         okhttp3            : 'com.squareup.okhttp3:okhttp:3.10.0'
-
 ]


### PR DESCRIPTION
Summary:
The support libraries where out of sync between the projects, causing
the sample build to fail with

```
> Android dependency 'com.android.support:appcompat-v7' has different version for the compile (26.1.0) and runtime (27.1.1) classpath. You should manually set the same version via DependencyResolution
```

This makes sure that the sample submodule uses the top-level
dependencies and same versions.

Test Plan:
./gradlew :sample:assembleDebug

(Still failing due to cmake for me, but no longer fails for the above
error.)