### PR TITLE
Fix parameters bug

### DIFF
--- a/iOS/SonarKit/CppBridge/SonarCppBridgingConnection.mm
+++ b/iOS/SonarKit/CppBridge/SonarCppBridgingConnection.mm
@@ -28,7 +28,7 @@
 
 - (void)send:(NSString *)method withParams:(NSDictionary *)params
 {
-  conn_->send([method UTF8String], facebook::cxxutils::convertIdToFollyDynamic(params, true));
+  conn_->send([method UTF8String], facebook::cxxutils::convertIdToFollyDynamic(params));
 }
 
 - (void)receive:(NSString *)method withBlock:(SonarReceiver)receiver


### PR DESCRIPTION
facebook::cxxutils::convertIdToFollyDynamic can only accept one paramter