### PR TITLE
Fix Logger issue in OSS build

### DIFF
--- a/src/fb-stubs/Logger.js
+++ b/src/fb-stubs/Logger.js
@@ -20,21 +20,11 @@ export default class LogManager {
 
   trackTimeSince(mark: string, eventName: ?string) {}
 
-  info(data: any, category: string) {
-    // eslint-disable-next-line
-    console.info(data, category);
-  }
+  info(data: any, category: string) {}
 
-  warn(data: any, category: string) {
-    console.warn(data, category);
-  }
+  warn(data: any, category: string) {}
 
-  error(data: any, category: string) {
-    console.error(data, category);
-  }
+  error(data: any, category: string) {}
 
-  debug(data: any, category: string) {
-    // eslint-disable-next-line
-    console.debug(data, category);
-  }
+  debug(data: any, category: string) {}
 }


### PR DESCRIPTION
We've replaced the global console.* methods with those in the Logger.
The OSS Logger uses a different implementation to the internal fb one, and it still calls back to console.*, causing a stack overflow.
Fix it by removing the console calls from Logger.js.
Logging to the original console methods is done by the Proxy in App.js.

Fixes #101 