### PR TITLE
Package prebuilt libraries in android target

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -224,6 +224,7 @@ android {
             res {
                 srcDir 'res'
             }
+            jniLibs.srcDirs = ['../third-party/OpenSSL/libs']
         }
     }
     externalNativeBuild {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -224,7 +224,7 @@ android {
             res {
                 srcDir 'res'
             }
-            jniLibs.srcDirs = ['../third-party/OpenSSL/libs']
+            jniLibs.srcDirs = ['third-party/OpenSSL/libs']
         }
     }
     externalNativeBuild {

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -22,7 +22,6 @@ android {
             res {
                 srcDir 'res'
             }
-            jniLibs.srcDirs = ['../third-party/OpenSSL/libs']
         }
     }
 


### PR DESCRIPTION
package prebuilt libraries in `:android` rather than in sample app