### PR TITLE
Update Litho dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ subprojects {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 
@@ -52,12 +51,12 @@ ext.deps = [
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.1',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',
         // Litho
-        lithoAnnotations   : 'com.facebook.litho:litho-annotations:0.15.1-SNAPSHOT',
-        lithoCore          : 'com.facebook.litho:litho-core:0.15.1-SNAPSHOT',
-        lithoWidget        : 'com.facebook.litho:litho-widget:0.15.1-SNAPSHOT',
-        lithoProcessor     : 'com.facebook.litho:litho-processor:0.15.1-SNAPSHOT',
-        lithoFresco        : 'com.facebook.litho:litho-fresco:0.15.1-SNAPSHOT',
-        lithoTesting       : 'com.facebook.litho:litho-testing:0.15.1-SNAPSHOT',
+        lithoAnnotations   : 'com.facebook.litho:litho-annotations:0.16.0',
+        lithoCore          : 'com.facebook.litho:litho-core:0.16.0',
+        lithoWidget        : 'com.facebook.litho:litho-widget:0.16.0',
+        lithoProcessor     : 'com.facebook.litho:litho-processor:0.16.0',
+        lithoFresco        : 'com.facebook.litho:litho-fresco:0.16.0',
+        lithoTesting       : 'com.facebook.litho:litho-testing:0.16.0',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
         robolectric        : 'org.robolectric:robolectric:3.0',

--- a/libs/fbjni/build.gradle
+++ b/libs/fbjni/build.gradle
@@ -36,6 +36,6 @@ dependencies {
     // compileOnly dependencies
     compileOnly deps.jsr305
     compileOnly deps.inferAnnotations
-    compileOnly 'com.facebook.litho:litho-annotations:0.15.0'
+    compileOnly deps.lithoAnnotations
     implementation deps.soloader
 }


### PR DESCRIPTION
Summary:
There's been a new stable release and we no longer need to depend on the
snapshot releases.

Test Plan:
./gradlew :sample:installDebug