### PR TITLE
[android] Exclude `libsonarfb.so` from sonar AAR

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -235,6 +235,10 @@ android {
         }
     }
 
+    packagingOptions {
+        exclude "**/libsonarfb.so"
+    }
+
     dependencies {
         implementation project(':fbjni')
         implementation deps.soloader

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -24,13 +24,6 @@ android {
             }
         }
     }
-
-   packagingOptions {
-        pickFirst 'lib/armeabi-v7a/libsonarfb.so'
-        pickFirst 'lib/x86/libsonarfb.so'
-        pickFirst 'lib/x86_64/libsonarfb.so'
-        pickFirst 'lib/arm64-v8a/libsonarfb.so'
-    }
 }
 
 


### PR DESCRIPTION
The default, even for libraries, is to include all downstream dependencies in the created AAR. This causes us to effectively provide `libsonarfb.so` twice, which creates unnecessary pain (see #24).