### PR TITLE
[android] Remove NDK build from fbjni sub-project

### DIFF
--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -24,13 +24,6 @@ android {
             }
         }
     }
-
-   packagingOptions {
-        pickFirst 'lib/armeabi-v7a/libsonarfb.so'
-        pickFirst 'lib/x86/libsonarfb.so'
-        pickFirst 'lib/x86_64/libsonarfb.so'
-        pickFirst 'lib/arm64-v8a/libsonarfb.so'
-    }
 }
 
 

--- a/libs/fbjni/build.gradle
+++ b/libs/fbjni/build.gradle
@@ -15,20 +15,6 @@ android {
                 }
             }
         }
-        ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-        }
-
-        externalNativeBuild {
-            cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang'
-            }
-        }
-    }
-    externalNativeBuild {
-        cmake {
-            path './CMakeLists.txt'
-        }
     }
 }
 


### PR DESCRIPTION
Summary:
We're already building this as dependency via CMake of sonar itself and
bundle the resulting `.so` files in there.

This project only contains the java files so we can ship them as
separate JAR.

Importantly, this avoids having to use `pickFirst` as we bundle multiple
incompatible `.so` files in both AARs.

Test Plan:
Published the result of this as `0.0.8` and built the sample app with
it.