### PR TITLE
[android] Setup fbjni sub-project for maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -195,15 +195,15 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
+
         ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-            stl 'c++_shared'
+            abiFilters 'x86', 'armeabi-v7a', 'arm64-v8a'
         }
 
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang'
-                arguments '-DANDROID_STL=c++_shared'
+                arguments '-DANDROID_TOOLCHAIN=clang',
+                    '-DANDROID_STL=c++_shared'
             }
         }
     }
@@ -236,10 +236,12 @@ android {
     }
 
     dependencies {
-        implementation project(':fbjni')
-        implementation deps.soloader
         compileOnly deps.lithoAnnotations
-        implementation 'org.glassfish:javax.annotation:10.0-b28'
+        compileOnly 'org.glassfish:javax.annotation:10.0-b28'
+
+        implementation project(':fbjni')
+
+        implementation deps.soloader
         implementation deps.guava
         implementation deps.jsr305
         implementation deps.supportAppCompat
@@ -253,6 +255,7 @@ android {
 
 project.afterEvaluate {
     preBuild.dependsOn prepareAllLibs
+}
 
 apply from: rootProject.file('gradle/release.gradle')
 
@@ -260,4 +263,5 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
 }
-artifacts.add('archives', sourcesJar)}
+
+artifacts.add('archives', sourcesJar)

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     // SoLoader
     implementation deps.soloader
 
-// For integration with Fresco
+    // For integration with Fresco
     implementation deps.lithoFresco
     // For testing
     testImplementation deps.lithoTesting

--- a/android/third-party/DoubleConversion/build.gradle
+++ b/android/third-party/DoubleConversion/build.gradle
@@ -8,10 +8,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
-        ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang'

--- a/android/third-party/Folly/build.gradle
+++ b/android/third-party/Folly/build.gradle
@@ -8,10 +8,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
-        ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'

--- a/android/third-party/LibEvent/build.gradle
+++ b/android/third-party/LibEvent/build.gradle
@@ -7,10 +7,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-        ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang'

--- a/android/third-party/OpenSSL/build.gradle
+++ b/android/third-party/OpenSSL/build.gradle
@@ -7,10 +7,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-        ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-        }
-
         externalNativeBuild {
             ndkBuild {
             arguments "NDK_APPLICATION_MK:=$projectDir/jni/Application.mk",

--- a/android/third-party/RSocket/build.gradle
+++ b/android/third-party/RSocket/build.gradle
@@ -7,10 +7,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-        ndk {
-            abiFilters 'arm64-v8a', 'x86', 'armeabi-v7a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang'

--- a/android/third-party/glog/build.gradle
+++ b/android/third-party/glog/build.gradle
@@ -8,10 +8,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
-        ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang'

--- a/libs/easywsclient/build.gradle
+++ b/libs/easywsclient/build.gradle
@@ -7,11 +7,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-
-        ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'

--- a/libs/fbjni/build.gradle
+++ b/libs/fbjni/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -24,4 +25,16 @@ dependencies {
     compileOnly deps.inferAnnotations
     compileOnly deps.lithoAnnotations
     implementation deps.soloader
+}
+
+apply from: rootProject.file('gradle/release.gradle')
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+artifacts.add('archives', sourcesJar)
+
+tasks.withType(Javadoc).all {
+    enabled = false
 }

--- a/libs/fbjni/gradle.properties
+++ b/libs/fbjni/gradle.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2014-present Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=SonarFBJNI
+POM_DESCRIPTION=Sonar-scoped FBJNI distribution
+POM_ARTIFACT_ID=fbjni
+POM_PACKAGING=aar

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,8 +21,6 @@ include ':libevent'
 include ':openssl'
 include ':rsocket'
 
-
-
 project(':fbjni').projectDir = file('libs/fbjni')
 project(':easywsclient').projectDir = file('libs/easywsclient')
 project(':sonarcpp').projectDir = file('xplat')

--- a/xplat/build.gradle
+++ b/xplat/build.gradle
@@ -7,11 +7,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-
-        ndk {
-            abiFilters 'arm64-v8a', 'x86'
-        }
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang'


### PR DESCRIPTION
Summary:
Set up our fbjni sub-project to be published to Maven Central.
This removes a bunch of abiFilters that we no longer make use of, too.

Test Plan:
Already used to published `v0.0.8` to JCenter which appears to work
quite well apart from the missing `x86_64` support.