### PR TITLE
Keep strong reference to OnSharedPreferenceChangeListener

### DIFF
--- a/android/plugins/sharedpreferences/SharedPreferencesSonarPlugin.java
+++ b/android/plugins/sharedpreferences/SharedPreferencesSonarPlugin.java
@@ -26,16 +26,17 @@ public class SharedPreferencesSonarPlugin implements SonarPlugin {
   private final SharedPreferences.OnSharedPreferenceChangeListener onSharedPreferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-      if (mConnection != null) {
-        mConnection.send(
-            "sharedPreferencesChange",
-            new SonarObject.Builder()
-                .put("name", key)
-                .put("deleted", !mSharedPreferences.contains(key))
-                .put("time", System.currentTimeMillis())
-                .put("value", mSharedPreferences.getAll().get(key))
-                .build());
+      if (mConnection == null) {
+        return;
       }
+      mConnection.send(
+          "sharedPreferencesChange",
+          new SonarObject.Builder()
+              .put("name", key)
+              .put("deleted", !mSharedPreferences.contains(key))
+              .put("time", System.currentTimeMillis())
+              .put("value", mSharedPreferences.getAll().get(key))
+              .build());
     }
   };
 


### PR DESCRIPTION
A strong reference to the listener should be kept when calling `registerOnSharedPreferenceChangeListener`, otherwise the listener can get garbage-collected and stop working.

Mentioned in the Android SDK docs [here](https://developer.android.com/reference/android/content/SharedPreferences.html#registerOnSharedPreferenceChangeListener(android.content.SharedPreferences.OnSharedPreferenceChangeListener)):

> Caution: The preference manager does not currently store a strong reference to the listener. You must store a strong reference to the listener, or it will be susceptible to garbage collection. We recommend you keep a reference to the listener in the instance data of an object that will exist as long as you need the listener.