### PR TITLE
Fix install for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ yarn
 yarn start
 ```
 
+NOTE: If you're on Windows, you need to use Yarn 1.5.1 until [this issue](https://github.com/yarnpkg/yarn/issues/6048) is resolved.
+
 ## Building the desktop app
 
 ```

--- a/scripts/yarn-install.js
+++ b/scripts/yarn-install.js
@@ -9,8 +9,9 @@ const glob = require('glob');
 const path = require('path');
 const {spawn} = require('child_process');
 const PACKAGES = ['static', 'src/plugins/*', 'src/fb/plugins/*'];
+const WINDOWS = /^win/.test(process.platform);
 const YARN_PATH =
-  process.argv.length > 2 ? path.join(__dirname, process.argv[2]) : 'yarn';
+  process.argv.length > 2 ? path.join(__dirname, process.argv[2]) : 'yarn' + (WINDOWS ? '.cmd' : '');
 
 Promise.all(
   PACKAGES.map(


### PR DESCRIPTION
This lets `yarn` work properly on Windows. Tested in a Cygwin environment. I also added a note about yarn compatibility to the readme.