### PR TITLE
Ignore header case to determine if content is gzipped

### DIFF
--- a/src/plugins/network/RequestDetails.js
+++ b/src/plugins/network/RequestDetails.js
@@ -57,7 +57,7 @@ function decodeBody(container: Request | Response): string {
   }
   const b64Decoded = atob(container.data);
   const encodingHeader = container.headers.find(
-    header => header.key === 'Content-Encoding',
+    header => header.key.toLowerCase() === 'content-encoding',
   );
 
   return encodingHeader && encodingHeader.value === 'gzip'


### PR DESCRIPTION
This PR updates the Network plugin's response parser to ignore the case of the `Content-Encoding` header in the response. This was preventing responses that are gzipped from being uncompressed. I tested this with gzipped responses through the OkHttp interceptor on Android. This could potentially address #79 as I was experiencing that issue before this change.

![sonar](https://user-images.githubusercontent.com/1328587/42414919-284b80bc-8238-11e8-8cf9-d9e9b9bea133.jpg)
