### PR TITLE
Added docs for OkHttp integration

### DIFF
--- a/docs/network-plugin.md
+++ b/docs/network-plugin.md
@@ -16,8 +16,23 @@ To use the network plugin, you need to add the plugin to your Sonar client insta
 ```java
 import com.facebook.sonar.plugins.network.NetworkSonarPlugin;
 
-client.addPlugin(new NetworkSonarPlugin());
+NetworkSonarPlugin networkSonarPlugin = new NetworkSonarPlugin();
+client.addPlugin(networkSonarPlugin);
 ```
+
+#### OkHttp Integration
+
+If you are using the popular OkHttp library, you can use the Interceptors system to automatically hook into your existing stack.
+
+```java
+import com.facebook.sonar.plugins.network.SonarOkhttpInterceptor;
+
+new OkHttpClient.Builder()
+    .addNetworkInterceptor(new SonarOkhttpInterceptor(networkSonarPlugin))
+    .build();
+```
+
+As interceptors can modify the request and response, add the Sonar interceptor after all others to get an accurate view of the network traffic.
 
 ### iOS
 


### PR DESCRIPTION
This PR includes documentation for using the `SonarOkhttpInterceptor` for applications using the `OkHttp` network stack. The docs were modelled on the [Stetho docs](http://facebook.github.io/stetho/#enable-network-inspection)

Fixes #22.