### PR TITLE
[android] Link against OpenSSL statically

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -148,7 +148,7 @@ task downloadOpenSSLSource(dependsOn: [], type: Download) {
 }
 
 task downloadOpenSSLLibs(dependsOn: [], type: Download) {
-    src 'https://github.com/passy/openssl-android/releases/download/1.1.0h/openssl-1.1.0h-prebuilt.tar.gz'
+    src 'https://github.com/passy/openssl-android/releases/download/1.1.0h-r2/openssl-1.1.0h-r2-prebuilt.tar.gz'
     onlyIfNewer true
     overwrite false
     dest new File(downloadsDir, 'openssl-1.1.0h-prebuilt.tar.gz');
@@ -237,9 +237,6 @@ android {
             }
             res {
                 srcDir 'res'
-            }
-            jniLibs {
-                srcDir "$thirdPartyNdkDir/OpenSSL/libs/"
             }
         }
     }

--- a/android/third-party/Folly/CMakeLists.txt
+++ b/android/third-party/Folly/CMakeLists.txt
@@ -135,8 +135,8 @@ target_include_directories(${PACKAGE_NAME} PRIVATE
 
 
 set(OPENSSL_LINK_DIRECTORIES ${PROJECT_SOURCE_DIR}/../OpenSSL/libs/${ANDROID_ABI}/)
-find_path(OPENSSL_LIBRARY libssl.so HINTS ${OPENSSL_LINK_DIRECTORIES})
+find_path(OPENSSL_LIBRARY libssl.a HINTS ${OPENSSL_LINK_DIRECTORIES})
 
 install(TARGETS ${PACKAGE_NAME}  DESTINATION ./build/)
 
-target_link_libraries(${PACKAGE_NAME} glog double-conversion ${OPENSSL_LINK_DIRECTORIES}/libssl.so ${OPENSSL_LINK_DIRECTORIES}/libcrypto.so event event_extra event_core)
+target_link_libraries(${PACKAGE_NAME} glog double-conversion ${OPENSSL_LINK_DIRECTORIES}/libssl.a ${OPENSSL_LINK_DIRECTORIES}/libcrypto.a event event_extra event_core)

--- a/android/third-party/RSocket/CMakeLists.txt
+++ b/android/third-party/RSocket/CMakeLists.txt
@@ -85,6 +85,6 @@ target_include_directories(${PACKAGE_NAME} PRIVATE
 
 set(OPENSSL_LINK_DIRECTORIES ${third_party_ndk}/OpenSSL/libs/${ANDROID_ABI}/)
 
-find_path(OPENSSL_LIBRARY libssl.so HINTS ${OPENSSL_LINK_DIRECTORIES})
+find_path(OPENSSL_LIBRARY libssl.a HINTS ${OPENSSL_LINK_DIRECTORIES})
 
-target_link_libraries(${PACKAGE_NAME}  folly glog double-conversion log event ${OPENSSL_LINK_DIRECTORIES}/libssl.so ${OPENSSL_LINK_DIRECTORIES}/libcrypto.so)
+target_link_libraries(${PACKAGE_NAME}  folly glog double-conversion log event ${OPENSSL_LINK_DIRECTORIES}/libssl.a ${OPENSSL_LINK_DIRECTORIES}/libcrypto.a)

--- a/xplat/CMakeLists.txt
+++ b/xplat/CMakeLists.txt
@@ -68,6 +68,6 @@ target_include_directories(${PACKAGE_NAME} PRIVATE
     )
 
 set(OPENSSL_LINK_DIRECTORIES ${third_party_ndk}/OpenSSL/libs/${ANDROID_ABI}/)
-find_path(OPENSSL_LIBRARY libssl.so HINTS ${OPENSSL_LINK_DIRECTORIES})
+find_path(OPENSSL_LIBRARY libssl.a HINTS ${OPENSSL_LINK_DIRECTORIES})
 
-target_link_libraries(${PACKAGE_NAME}  folly rsocket glog double-conversion log event ${OPENSSL_LINK_DIRECTORIES}/libssl.so ${OPENSSL_LINK_DIRECTORIES}/libcrypto.so)
+target_link_libraries(${PACKAGE_NAME} folly rsocket glog double-conversion log event ${OPENSSL_LINK_DIRECTORIES}/libssl.a ${OPENSSL_LINK_DIRECTORIES}/libcrypto.a)

--- a/xplat/build.gradle
+++ b/xplat/build.gradle
@@ -30,4 +30,3 @@ android {
         implementation project(':folly')
     }
 }
-//'armeabi-v7a'


### PR DESCRIPTION
Summary:
Compile against a static version of OpenSSL for better compatibility
with apps that already use OpenSSL in some fashion.

Test Plan:
```
./gradlew :android:assembleRelease
unzip -l android/build/outputs/aar/sonar-release.aar | rg ssl
./gradlew :sample:installDebug
```

Fixes #148.