### PR TITLE
[android] Remove `third-party` from dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,6 @@ android {
     dependencies {
         compileOnly deps.lithoAnnotations
         implementation project(':fbjni')
-        implementation project(':third-party')
         implementation deps.soloader
         implementation deps.guava
         implementation deps.jsr305


### PR DESCRIPTION
Summary:
`:third-party` doesn't actually export anything. So we don't need to
explicitly depend on it as it messes with the POM generation otherwise.

Test Plan:
build the AAR