### PR TITLE
Fix some typos (it's vs its)

### DIFF
--- a/docs/jssetup.md
+++ b/docs/jssetup.md
@@ -34,7 +34,7 @@ Learn more on how to use [Sonar's UI components](ui-components.md).
 
 ### Dynamically loading plugins
 
-Once a plugin is created, Sonar can load it from it's folder. The path from where the plugins are loaded is specified in `~/.sonar/config.json`. Add the parent folder of your plugin to `pluginPaths` and start Sonar.
+Once a plugin is created, Sonar can load it from its folder. The path from where the plugins are loaded is specified in `~/.sonar/config.json`. Add the parent folder of your plugin to `pluginPaths` and start Sonar.
 
 ### npm dependencies
 

--- a/docs/styling-components.md
+++ b/docs/styling-components.md
@@ -4,7 +4,7 @@ title: Styling Components
 sidebar_label: Styling Components
 ---
 
-We use a styled-component based approach to styling our views. This means styles are defined in JavaScript and are written as CSS-stylesheets to the DOM. A component and it's styles are coupled. Styled components can extend another to inherit their styles.
+We use a styled-component based approach to styling our views. This means styles are defined in JavaScript and are written as CSS-stylesheets to the DOM. A component and its styles are coupled. Styled components can extend another to inherit their styles.
 
 ## Basic tags
 

--- a/libs/fbjni/cxx/fbjni/detail/CoreClasses.h
+++ b/libs/fbjni/cxx/fbjni/detail/CoreClasses.h
@@ -83,7 +83,7 @@ bool isSameObject(alias_ref<JObject> lhs, alias_ref<JObject> rhs) noexcept;
 //
 // While users of a JavaClass-type can lookup methods and fields through the
 // underlying JClass, those calls can only be checked at runtime. It is recommended
-// that the JavaClass-type instead explicitly expose it's methods as in the example
+// that the JavaClass-type instead explicitly expose its methods as in the example
 // above.
 
 namespace detail {

--- a/libs/fbjni/cxx/fbjni/detail/Meta.h
+++ b/libs/fbjni/cxx/fbjni/detail/Meta.h
@@ -33,7 +33,7 @@
 namespace facebook {
 namespace jni {
 
-// This will get the reflected Java Method from the method_id, get it's invoke
+// This will get the reflected Java Method from the method_id, get its invoke
 // method, and call the method via that. This shouldn't ever be needed, but
 // Android 6.0 crashes when calling a method on a java.lang.Proxy via jni.
 template <typename... Args>

--- a/libs/fbjni/cxx/fbjni/fbjni.cpp
+++ b/libs/fbjni/cxx/fbjni/fbjni.cpp
@@ -104,7 +104,7 @@ local_ref<JString> make_jstring(const char* utf8) {
     // The only difference between utf8 and modifiedUTF8 is in encoding 4-byte UTF8 chars
     // and '\0' that is encoded on 2 bytes.
     //
-    // Since modifiedUTF8-encoded string can be no shorter than it's UTF8 conterpart we
+    // Since modifiedUTF8-encoded string can be no shorter than its UTF8 conterpart we
     // know that if those two strings are of the same length we don't need to do any
     // conversion -> no 4-byte chars nor '\0'.
     result = env->NewStringUTF(utf8);

--- a/src/plugins/layout/index.js
+++ b/src/plugins/layout/index.js
@@ -571,7 +571,7 @@ export default class Layout extends SonarPlugin<InspectorState> {
       // expand current element
       const children = await this.setElementExpanded(key, true, ax);
 
-      // and add it's children to the queue
+      // and add its children to the queue
       for (const child of children) {
         keys.push(child.id);
       }

--- a/src/ui/components/Tab.js
+++ b/src/ui/components/Tab.js
@@ -20,7 +20,7 @@ export default function Tab(props: {|
    */
   hidden?: boolean,
   /**
-   * Whether this tab should always be included in the DOM and have it's
+   * Whether this tab should always be included in the DOM and have its
    * visibility toggled.
    */
   persist?: boolean,

--- a/src/ui/components/Tabs.js
+++ b/src/ui/components/Tabs.js
@@ -113,7 +113,7 @@ export default function Tabs(props: {|
   order?: Array<string>,
   /**
    * Whether to include the contents of every tab in the DOM and just toggle
-   * it's visibility.
+   * its visibility.
    */
   persist?: boolean,
   /**
@@ -186,7 +186,7 @@ export default function Tabs(props: {|
         );
       }
 
-      // this tab has been hidden from the tab bar but can still be selected if it's key is active
+      // this tab has been hidden from the tab bar but can still be selected if its key is active
       if (comp.props.hidden) {
         continue;
       }

--- a/src/ui/components/data-inspector/DataInspector.js
+++ b/src/ui/components/data-inspector/DataInspector.js
@@ -101,7 +101,7 @@ type DataInspectorProps = {
    */
   depth: number,
   /**
-   * An array containing the current location of the data relative to it's root.
+   * An array containing the current location of the data relative to its root.
    */
   path: Array<string>,
   /**
@@ -113,7 +113,7 @@ type DataInspectorProps = {
    */
   expanded: DataInspectorExpanded,
   /**
-   * An optional callback that will explode a value into it's type and value.
+   * An optional callback that will explode a value into its type and value.
    * Useful for inspecting serialised data.
    */
   extractValue?: DataValueExtractor,
@@ -462,7 +462,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
     if (isExpandable && isExpanded) {
       const propertyNodes = [];
 
-      // ancestry of children, including it's owner object
+      // ancestry of children, including its owner object
       const childAncestry = ancestry.concat([value]);
 
       const diffValue = diff && resDiff ? resDiff.value : null;

--- a/src/ui/components/data-inspector/ManagedDataInspector.js
+++ b/src/ui/components/data-inspector/ManagedDataInspector.js
@@ -27,7 +27,7 @@ type ManagedDataInspectorProps = {|
    */
   expandRoot?: boolean,
   /**
-   * An optional callback that will explode a value into it's type and value.
+   * An optional callback that will explode a value into its type and value.
    * Useful for inspecting serialised data.
    */
   extractValue?: DataValueExtractor,

--- a/src/ui/styled/__tests__/index.node.js
+++ b/src/ui/styled/__tests__/index.node.js
@@ -127,7 +127,7 @@ test('should inherit component when passed as first arg to styled', () => {
   }
 });
 
-test("when passed class name of another styled component it's rules should be inherited", () => {
+test("when passed class name of another styled component its rules should be inherited", () => {
   let component;
 
   try {

--- a/src/ui/styled/gc.js
+++ b/src/ui/styled/gc.js
@@ -53,7 +53,7 @@ export class GarbageCollector {
     }
   }
 
-  // component has been unmounted so remove it's dependencies
+  // component has been unmounted so remove its dependencies
   deregisterClassUse(name: string) {
     let count = this.usedClasses.get(name);
     if (count == null) {

--- a/src/utils/CertificateProvider.js
+++ b/src/utils/CertificateProvider.js
@@ -191,7 +191,7 @@ export default class CertificateProvider {
         // To find out which device requested the cert, search them
         // all for a matching csr file.
         // It's not important to keep these secret from other apps.
-        // Just need to make sure each app can find it's own one.
+        // Just need to make sure each app can find its own one.
         this.androidDeviceHasMatchingCSR(
           deviceCsrFilePath,
           device.id,


### PR DESCRIPTION
I noticed that there was a typo in the documentation ("it's" should have been "its"). I ended up fixing some occurrences of this typo in some code comments as well.